### PR TITLE
feat: add support to Xai Network (Mainnet and Testnet Sepolia) (#9)

### DIFF
--- a/src/networks.ts
+++ b/src/networks.ts
@@ -418,4 +418,26 @@ export const networkInfo = new Map<number, NetworkInfo>([
       stagingBaseAPI: 'https://transaction-testnet.staging.safe.kava.io',
     },
   ],
+  [
+    660279,
+    {
+      chainID: 660279,
+      name: 'Xai',
+      shortName: 'xai',
+      currencySymbol: 'XAI',
+      baseAPI: 'https://transaction.safe.xai.games',
+      stagingBaseAPI: 'https://transaction.staging.safe.xai.games',
+    },
+  ],
+  [
+    37714555429,
+    {
+      chainID: 37714555429,
+      name: 'Xai Testnet Sepolia',
+      shortName: 'xaitestnet',
+      currencySymbol: 'sXAI',
+      baseAPI: 'https://transaction-testnet.safe.xai.games',
+      stagingBaseAPI: 'https://transaction-testnet.staging.safe.xai.games',
+    },
+  ],
 ]);


### PR DESCRIPTION
This PR adds support for the Xai Network on production environment, including both:

- [x] Xai Mainnet [Chain ID: 660279]

- [x] Xai Testnet (Sepolia) [Chain ID: 37714555429]